### PR TITLE
Some cmake fixes + enabling CI 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,48 @@
+language: cpp
+
+sudo: false
+
+addons:
+  apt:
+    sources:
+      - ubuntu-toolchain-r-test
+      - george-edison55-precise-backports
+    packages:
+      - ccache
+      - cmake
+      - cmake-data
+      - libopenmpi-dev
+      - openmpi-bin
+      - gcc-5
+      - g++-5
+      - bc
+
+before_install:
+ - git -C cinch submodule init && git -C cinch submodule update
+ - git fetch --tags
+ - if [[ ${COVERAGE}  ]]; then pip install --user codecov; fi 
+
+env: #maybe add mpich later
+  global:
+    - CCACHE_CPP2=yes
+    - GVER=5
+  matrix:
+#    - MPI=ON
+    - MPI=OFF
+#    - MPI=ON  COVERAGE=ON
+    - MPI=OFF COVERAGE=ON
+
+script:
+  - mkdir build && cd build &&
+    PATH="/usr/lib/ccache:$PATH" CC=gcc-${GVER} CXX=g++-${GVER} cmake -DENABLE_MPI=$MPI -DENABLE_UNIT_TESTS=ON ${COVERAGE:+-DUSE_GCOV=ON} .. && 
+    make -j2 && make test && make install DESTDIR="${HOME}"
+
+after_success:
+  - if [[ ${COVERAGE} ]]; then cd .. && codecov --gcov-exec gcov-${GVER}; fi
+
+cache:
+  directories:
+    - $HOME/.ccache
+
+compiler:
+  - gcc

--- a/config/packages.cmake
+++ b/config/packages.cmake
@@ -73,15 +73,19 @@ endif(FLECSI_RUNTIME_MODEL STREQUAL "serial")
 # Process id bits
 #------------------------------------------------------------------------------#
 
-execute_process(COMMAND echo "60-${FLECSI_ID_PBITS}" COMMAND bc -l
+find_program(BC bc DOC "bc executable")
+if(NOT BC)
+  message(FATAL_ERROR "bc executable not found")  
+endif(NOT BC)
+execute_process(COMMAND echo "60-${FLECSI_ID_PBITS}" COMMAND ${BC} -l
   OUTPUT_VARIABLE FLECSI_ID_EBITS OUTPUT_STRIP_TRAILING_WHITESPACE)
 
 add_definitions(-DFLECSI_ID_PBITS=${FLECSI_ID_PBITS})
 add_definitions(-DFLECSI_ID_EBITS=${FLECSI_ID_EBITS})
 
-execute_process(COMMAND echo "2^${FLECSI_ID_PBITS}" COMMAND bc -l
+execute_process(COMMAND echo "2^${FLECSI_ID_PBITS}" COMMAND ${BC} -l
   OUTPUT_VARIABLE flecsi_partitions OUTPUT_STRIP_TRAILING_WHITESPACE)
-execute_process(COMMAND echo "2^${FLECSI_ID_EBITS}" COMMAND bc -l
+execute_process(COMMAND echo "2^${FLECSI_ID_EBITS}" COMMAND ${BC} -l
   OUTPUT_VARIABLE flecsi_entities OUTPUT_STRIP_TRAILING_WHITESPACE)
 
 message(STATUS "Set id_t bits to allow ${flecsi_partitions} partitions with ${flecsi_entities} entities each")

--- a/config/project.cmake
+++ b/config/project.cmake
@@ -58,6 +58,15 @@ if (NOT TPL_INSTALL_PREFIX STREQUAL "")
   set(SCOTCH_ROOT ${TPL_INSTALL_PREFIX})
 endif()
 
+option(USE_GCOV "Enable gcov support" OFF)
+if(USE_GCOV)
+  message(STATUS "Enabling gcov support")
+  set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} --coverage -O0")
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} --coverage -O0")
+  set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} --coverage")
+  set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} --coverage")
+endif()
+
 #~---------------------------------------------------------------------------~-#
 # Formatting options
 # vim: set tabstop=2 shiftwidth=2 expandtab :

--- a/src/data/CMakeLists.txt
+++ b/src/data/CMakeLists.txt
@@ -12,10 +12,10 @@
 # All rights reserved
 #~----------------------------------------------------------------------------~#
 
-set(data_HEADERS
-  state.h
-  PARENT_SCOPE
-)
+#set(data_HEADERS
+#  state.h
+#  PARENT_SCOPE
+#)
 
 #set(data_SOURCES
 #  PARENT_SCOPE


### PR DESCRIPTION
- added check for `bc`
- don't install non-existing `state.h`
- add code coverage option `USE_GCOV`
- enable non-mpi build with/without code coverage

@charest , @ddaniel : please review